### PR TITLE
[+] BO : added gSitemapAppendUrls hook

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -126,7 +126,7 @@ class Gsitemap extends Module
 			if (!Configuration::deleteByName($key))
 				return false;
 
-		$hook = new Hook(Hook::getIdByName($hook_name));
+		$hook = new Hook(Hook::getIdByName(self::HOOK_ADD_URLS));
 		if (Validate::isLoadedObject($hook))
 			$hook->delete();
 


### PR DESCRIPTION
Introduced `gSitemapAppendUrls` hook allows other modules to append new URLs to the generated sitemap

Requested refactoring of https://github.com/PrestaShop/PrestaShop-modules/pull/346 to fit updated module.
/!\ Untested refactoring
