### PR TITLE
BO: gsitemap: Generate sitemaps only for languages associated to shop

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -704,7 +704,7 @@ class Gsitemap extends Module
 			$this->context->shop = new Shop((int)$id_shop);
 
 		$type = Tools::getValue('type') ? Tools::getValue('type') : '';
-		$languages = Language::getLanguages(true, $id_shop);
+		$languages = Language::getLanguages(true, $this->context->shop->id);
 		$lang_stop = Tools::getValue('lang') ? true : false;
 		$id_obj = Tools::getValue('id') ? (int)Tools::getValue('id') : 0;
 		foreach ($languages as $lang)


### PR DESCRIPTION
Fix the situation where function argument 'id_shop' equals to 0 (predefined value).
In this case sitemaps will be generated only for languages associated to
current shop, not for all installed languages.

If sitemaps are generated for all installed languages and shop has only some
of them associated, sitemaps then point to non-existend localized pages (routes)
which generates errors on search engines' sitemaps processing.
