### PR TITLE
1.7.0.x-prev: Use only the languages assigned to the shop

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -704,7 +704,7 @@ class Gsitemap extends Module
 			$this->context->shop = new Shop((int)$id_shop);
 
 		$type = Tools::getValue('type') ? Tools::getValue('type') : '';
-		$languages = Language::getLanguages(true, $id_shop);
+		$languages = Language::getLanguages(true, $this->context->shop->id);
 		$lang_stop = Tools::getValue('lang') ? true : false;
 		$id_obj = Tools::getValue('id') ? (int)Tools::getValue('id') : 0;
 		foreach ($languages as $lang)


### PR DESCRIPTION
In the 53122f646f4c1b6889f2c3297abf2109d0e9d54a commit the `$id_shop` parameter used to query languages, but if that was not specified, it generated the list in all languages.

Use the context store ID instead: if the parameter is specified, the context follows it.