### PR TITLE
Change include init.php place

### DIFF
--- a/gsitemap-cron.php
+++ b/gsitemap-cron.php
@@ -29,10 +29,11 @@
  */
 
 include(dirname(__FILE__) . '/../../config/config.inc.php');
-include(dirname(__FILE__) . '/../../init.php');
 
 /* Check security token */
 if (!Tools::isPHPCLI()) {
+    include(dirname(__FILE__) . '/../../init.php');
+
     if (Tools::substr(Tools::encrypt('gsitemap/cron'), 0, 10) != Tools::getValue('token') || !Module::isInstalled('gsitemap')) {
         die('Bad token');
     }


### PR DESCRIPTION
Change init.php for don't include this if you use phpCLI. 

the reason:
* if you include but you run gsitemap-cron.php with phpCLI with PS_SSL_ENABLED at 1 the exit script.

**How to test:**

Run gsitemap-cron.php in CLI with SSL activated