### PR TITLE
Add all images of a product to the sitemap, instead of only the cover image

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -673,7 +673,7 @@ class Gsitemap extends Module
                 $images[] = $file['image'];
             }
             if (isset($file['images']) && $file['images']) {
-                $images = $images + $file['images'];
+                $images = array_merge($images, $file['images']);
             }
             foreach($images as $image) {
                 $this->addSitemapNodeImage($write_fd, htmlspecialchars(strip_tags($image['link'])), isset($image['title_img']) ? htmlspecialchars(str_replace(array(


### PR DESCRIPTION
This change adds an `<image:image>` field for each image of a product. All images still have the same label.
Having multiple `<image:image>` for a single node in a sitemap is authorized by the schema version 0.9.