### PR TITLE
Creates the sitemap only for the selected shop in multistore sites.

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -182,11 +182,11 @@ class Gsitemap extends Module
             }
             Configuration::updateValue('GSITEMAP_DISABLE_LINKS', $meta);
             $this->emptySitemap();
-            $this->createSitemap();
+            $this->createSitemap(Tools::getValue('id_shop'), 0);
 
         /* If no posted form and the variable [continue] is found in the HTTP request variable keep creating sitemap */
         } elseif (Tools::getValue('continue')) {
-            $this->createSitemap();
+            $this->createSitemap(Tools::getValue('id_shop'), 0);
         }
 
         /* Empty the Shop domain cache */
@@ -200,7 +200,7 @@ class Gsitemap extends Module
         });
         $store_url = $this->context->link->getBaseLink();
         $this->context->smarty->assign(array(
-            'gsitemap_form' => './index.php?tab=AdminModules&configure=gsitemap&token=' . Tools::getAdminTokenLite('AdminModules') . '&tab_module=' . $this->tab . '&module_name=gsitemap',
+            'gsitemap_form' => './index.php?tab=AdminModules&configure=gsitemap&token=' . Tools::getAdminTokenLite('AdminModules') . '&tab_module=' . $this->tab . '&module_name=gsitemap&id_shop=' . $this->context->shop->id,
             'gsitemap_cron' => $store_url . 'modules/gsitemap/gsitemap-cron.php?token=' . Tools::substr(Tools::encrypt('gsitemap/cron'), 0, 10) . '&id_shop=' . $this->context->shop->id,
             'gsitemap_feed_exists' => file_exists($this->normalizeDirectory(_PS_ROOT_DIR_) . 'index_sitemap.xml'),
             'gsitemap_last_export' => Configuration::get('GSITEMAP_LAST_EXPORT'),


### PR DESCRIPTION
The method `createSitemap($id_shop = 0)` takes a parameter indicating 
the current shop which is never actually passed. As a result of that, 
the module ignores the selected shop in the admin toolbar. 

To further complicate things, if you have a multistore deployement with 
2 shops and 4 langs, the 2 1st langs enabled for shop 1, the remaining 2 
for shop 2, creating the sitemap would create the sub-sitemaps for all 
the 4 langs, which clearly is not the expected outcome.

This patch solves the problem and passes the selected shop to the 
`createSitemap` method.

Fixes https://github.com/PrestaShop/PrestaShop/issues/18649