### PR TITLE
#113 - Apply the fix from @mathieuhen

### DIFF
--- a/gsitemap-cron.php
+++ b/gsitemap-cron.php
@@ -48,8 +48,8 @@ if ($gsitemap->active) {
     foreach ($shops as $shop) {
         $list_id_shop[] = (int) $shop['id_shop'];
     }
-    
-    $id_shop = (Tools::getIsset(Tools::getValue('id_shop')) && in_array(Tools::getValue('id_shop'), $list_id_shop)) ? (int) Tools::getValue('id_shop') : (int) Configuration::get('PS_SHOP_DEFAULT');
+
+    $id_shop = (Tools::getIsset('id_shop') && in_array(Tools::getValue('id_shop'), $list_id_shop)) ? (int) Tools::getValue('id_shop') : (int) Configuration::get('PS_SHOP_DEFAULT');
     $gsitemap->cron = true;
     
     /* for the main run initiat the sitemap's files name stored in the database */


### PR DESCRIPTION
Nobody corrected this issue and my team and I came across this bug, so I decided to push this fix for the rest of the community 

### The issue: 
In a multistore environment, the link provided in the BO to recreate the sitemap was only doing the store 1, no matter on which store you are, it will only do the store 1 

Which is pretty annoying when you want to automate the process 