### PR TITLE
Fix undefined index, fix form headings

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -593,8 +593,7 @@ class Gsitemap extends Module
     public function createSitemap($id_shop = 0)
     {
         if (@fopen($this->normalizeDirectory(_PS_ROOT_DIR_) . '/test.txt', 'wb') == false) {
-            $this->context->smarty->assign('google_maps_error', $this->trans('An error occured while trying to check your file permissions. Please adjust your permissions to allow PrestaShop to write a file in your root directory.', [], 'Modules.Gsitemap.Admin'));
-
+            $this->context->controller->errors[] = $this->trans('An error occured while trying to check your file permissions. Please adjust your permissions to allow PrestaShop to write a file in your root directory.', [], 'Modules.Gsitemap.Admin');
             return false;
         } else {
             @unlink($this->normalizeDirectory(_PS_ROOT_DIR_) . 'test.txt');

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -594,6 +594,7 @@ class Gsitemap extends Module
     {
         if (@fopen($this->normalizeDirectory(_PS_ROOT_DIR_) . '/test.txt', 'wb') == false) {
             $this->context->controller->errors[] = $this->trans('An error occured while trying to check your file permissions. Please adjust your permissions to allow PrestaShop to write a file in your root directory.', [], 'Modules.Gsitemap.Admin');
+
             return false;
         } else {
             @unlink($this->normalizeDirectory(_PS_ROOT_DIR_) . 'test.txt');

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -478,7 +478,7 @@ class Gsitemap extends Module
             }
             $file_headers = (Configuration::get('GSITEMAP_CHECK_IMAGE_FILE') && isset($image_link)) ? @get_headers($image_link) : true;
             $image_category = [];
-            if (isset($image_link) && ($file_headers[0] != 'HTTP/1.1 404 Not Found' || $file_headers === true)) {
+            if (isset($image_link) && ((isset($file_headers[0]) && $file_headers[0] != 'HTTP/1.1 404 Not Found') || $file_headers === true)) {
                 $image_category = [
                     'title_img' => htmlspecialchars(strip_tags($category->name)),
                     'caption' => Tools::substr(htmlspecialchars(strip_tags($category->description)), 0, 350),

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -1,6 +1,2 @@
 includes:
     - %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Access to an undefined property Cookie\:\:\$id_lang.#'

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -33,9 +33,9 @@
 {/if}
 
 <div class="panel">
+   <div class="panel-heading"><i class="icon icon-sitemap"></i> {l s='Your sitemaps' d='Modules.Gsitemap.Admin'}</div>
 
    {if isset($gsitemap_refresh_page)}
-   <h3><i class="icon icon-sitemap"></i> {l s='Your sitemaps' d='Modules.Gsitemap.Admin'}</h3>
    <p>{$gsitemap_number|intval} {l s='Sitemaps were already created.' d='Modules.Gsitemap.Admin'}</p>
    <br><br>
    <form action="{$gsitemap_refresh_page|escape:'htmlall':'UTF-8'}" method="post" id="gsitemap_generate_sitmap">
@@ -44,7 +44,6 @@
    </form>
    {else}
    {if $gsitemap_links}
-   <h3><i class="icon icon-sitemap"></i> {l s='Your sitemaps' d='Modules.Gsitemap.Admin'}</h3>
    {l s='Please set up the following sitemap URL in your Google Webmaster account:' d='Modules.Gsitemap.Admin'}<br>
    <a href="{$gsitemap_store_url|escape:'htmlall':'UTF-8'}{$shop->id|intval}_index_sitemap.xml" target="_blank">{$gsitemap_store_url|escape:'htmlall':'UTF-8'}{$shop->id|intval}_index_sitemap.xml</a><br><br>
    {l s='The above URL is the master sitemap file. It refers to the following sub-sitemap files:' d='Modules.Gsitemap.Admin'}
@@ -57,9 +56,7 @@
    </div>
    <p>{l s='Your last update was made on this date:' d='Modules.Gsitemap.Admin'} {$gsitemap_last_export|escape:'htmlall':'UTF-8'}</p>
    {else}
-   <h3><i class="icon icon-sitemap"></i> {l s='Your sitemaps' d='Modules.Gsitemap.Admin'}</h3>
-   <p>{l s='This shop has no sitemap yet.' d='Modules.Gsitemap.Admin'}<br>
-   </p>
+   <p>{l s='This shop has no sitemap yet.' d='Modules.Gsitemap.Admin'}</p>
    {/if}
    {if ($gsitemap_customer_limit.max_exec_time < 30 && $gsitemap_customer_limit.max_exec_time > 0) || ($gsitemap_customer_limit.memory_limit < 128 && $gsitemap_customer_limit.memory_limit > 0)}
    <br>

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -33,11 +33,7 @@
 {/if}
 
 <div class="panel">
-   {if isset($google_maps_error)}
-   <div class="error">
-      {$google_maps_error|escape:'htmlall':'UTF-8'}<br>
-   </div>
-   {/if}
+
    {if isset($gsitemap_refresh_page)}
    <h3><i class="icon icon-sitemap"></i> {l s='Your sitemaps' d='Modules.Gsitemap.Admin'}</h3>
    <p>{$gsitemap_number|intval} {l s='Sitemaps were already created.' d='Modules.Gsitemap.Admin'}</p>
@@ -87,7 +83,7 @@
 
 <div class="panel">
    <form action="{$gsitemap_form|escape:'htmlall':'UTF-8'}" method="post">
-      <h3><i class="icon icon-wrench"></i> {l s='Configure your sitemap' d='Modules.Gsitemap.Admin'}</h3>
+      <div class="panel-heading"><i class="icon icon-wrench"></i> {l s='Configure your sitemap' d='Modules.Gsitemap.Admin'}</div>
       <p>{l s='Several sitemap files will be generated depending on how your server is configured and on the number of activated products in your catalog.' d='Modules.Gsitemap.Admin'}<br></p>
       <div class="margin-form">
          <label for="gsitemap_frequency" >{l s='How often do you update your store?' d='Modules.Gsitemap.Admin'}
@@ -128,7 +124,7 @@
 </div>
 
 <div class="panel">
-   <h3><i class="icon icon-tags"></i> {l s='Information' d='Modules.Gsitemap.Admin'}</h3>
+   <div class="panel-heading"><i class="icon icon-tags"></i> {l s='Information' d='Modules.Gsitemap.Admin'}</div>
    <p>
       <strong>{l s='You have two ways to generate sitemaps.' d='Modules.Gsitemap.Admin'}</strong><br><br>
       1. <strong>{l s='Manually:' d='Modules.Gsitemap.Admin'}</strong> {l s='Using the form above (as often as needed)' d='Modules.Gsitemap.Admin'}<br>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read below
| Type?         | bug fix / refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#30221
| How to test?  | Generate sitemap and see that no notices are thrown and the config form looks somehow OK.

### Changes
- Error about directory not being writeable is shown by notification, not generated manually. I used context error notifications for this.
- Fixed panel headings by using proper syntax. It should be a div `panel-heading`, not a h3. Fixes a tiny bug.
![Snímek obrazovky 2022-12-03 142813](https://user-images.githubusercontent.com/6097524/205443159-2423fe60-728a-4f96-aa91-d2394bd59fe9.jpg)
- Fixed notices where it was trying to access `[0]` on a `boolean`. Simmilar fix was applied for products, but not for categories.