### PR TITLE
Check if the hook is present before adding it

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -111,12 +111,17 @@ class Gsitemap extends Module
     }
 
     /**
-     * Registers hook(s)
+     * Check if the hook is present in the system or add it
      *
      * @return bool
      */
     protected function installHook()
     {
+        $hook = new Hook(Hook::getIdByName(self::HOOK_ADD_URLS));
+        if (Validate::isLoadedObject($hook)) {
+            return;
+        }
+
         $hook = new Hook();
         $hook->name = self::HOOK_ADD_URLS;
         $hook->title = 'GSitemap Append URLs';
@@ -149,11 +154,6 @@ class Gsitemap extends Module
             if (!Configuration::deleteByName($key)) {
                 return false;
             }
-        }
-
-        $hook = new Hook(Hook::getIdByName(self::HOOK_ADD_URLS));
-        if (Validate::isLoadedObject($hook)) {
-            $hook->delete();
         }
 
         return parent::uninstall() && $this->removeSitemap();

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -119,7 +119,7 @@ class Gsitemap extends Module
     {
         $hook = new Hook(Hook::getIdByName(self::HOOK_ADD_URLS));
         if (Validate::isLoadedObject($hook)) {
-            return;
+            return true;
         }
 
         $hook = new Hook();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Checks if the sitemap hook is not present in the system, otherwise the adding would fail. The hook can be there from other modules, fixtures or my a failed uninstall. Also I removed the removal of the hook during uninstall - because you would lost all modules hooked into there, and they would not get rehooked.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below

➡️ Make sure to replace `PREFIX_` in the queries with `ps_` or whatever your prefix is.

### How to test - scenario A
1. Uninstall this module.
2. Run following query in PHPMYADMIN. The hook may fail if you already have the hook there, but it's not a problem.

```sql
INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES 
(NULL, 'gSitemapAppendUrls', 'GSitemap Append URLs', 'This hook allows a module to add URLs to a generated sitemap', '1');
```

3. Verify the hook is there by running:

```sql
SELECT * FROM `PREFIX_hook` WHERE name = 'gSitemapAppendUrls';
```

4. Install this module. It will work. It may not work without this PR.

### How to test - scenario B
1. Uninstall this module.
2. Verify the hook stayed in the database by running. It was deleted before. With this PR, it stays.

```sql
SELECT * FROM `PREFIX_hook` WHERE name = 'gSitemapAppendUrls';
```