### PR TITLE
Fix issue with only max 20 XML sitemap files generated on cron jobs

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -277,42 +277,41 @@ class Gsitemap extends Module
             ++$i;
 
             return true;
-        } else {
-            $this->recursiveSitemapCreator($link_sitemap, $lang, $index);
-            if ($index % 20 == 0 && !$this->cron) {
-                $this->context->smarty->assign([
-                    'gsitemap_number' => (int) $index,
-                    'gsitemap_refresh_page' => $this->context->link->getAdminLink('AdminModules', true, [], [
-                        'tab_module' => $this->tab,
-                        'module_name' => $this->name,
-                        'continue' => 1,
-                        'type' => $new_link['type'],
-                        'lang' => $lang,
-                        'index' => $index,
-                        'id' => (int) $id_obj,
-                        'id_shop' => $this->context->shop->id,
-                    ]),
-                ]);
+        }
 
-                return false;
-            } else {
-                if ($this->cron) {
-                    Tools::redirect($this->context->link->getBaseLink() . 'modules/gsitemap/gsitemap-cron.php?continue=1&token=' . Tools::substr(Tools::hash('gsitemap/cron'), 0, 10) . '&type=' . $new_link['type'] . '&lang=' . $lang . '&index=' . $index . '&id=' . (int) $id_obj . '&id_shop=' . $this->context->shop->id);
-                } else {
-                    Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], [
-                        'tab_module' => $this->tab,
-                        'module_name' => $this->name,
-                        'configure' => $this->name,
-                        'continue' => 1,
-                        'type' => $new_link['type'],
-                        'lang' => $lang,
-                        'index' => $index,
-                        'id' => (int) $id_obj,
-                        'id_shop' => $this->context->shop->id,
-                    ]));
-                }
-                exit();
-            }
+        $this->recursiveSitemapCreator($link_sitemap, $lang, $index);
+        if ($index % 20 == 0 && !$this->cron) {
+            $this->context->smarty->assign([
+                'gsitemap_number' => (int) $index,
+                'gsitemap_refresh_page' => $this->context->link->getAdminLink('AdminModules', true, [], [
+                    'tab_module' => $this->tab,
+                    'module_name' => $this->name,
+                    'continue' => 1,
+                    'type' => $new_link['type'],
+                    'lang' => $lang,
+                    'index' => $index,
+                    'id' => (int) $id_obj,
+                    'id_shop' => $this->context->shop->id,
+                ]),
+            ]);
+
+            return false;
+        }
+
+        if ($this->cron) {
+            Tools::redirect($this->context->link->getBaseLink() . 'modules/gsitemap/gsitemap-cron.php?continue=1&token=' . Tools::substr(Tools::hash('gsitemap/cron'), 0, 10) . '&type=' . $new_link['type'] . '&lang=' . $lang . '&index=' . $index . '&id=' . (int) $id_obj . '&id_shop=' . $this->context->shop->id);
+        } else {
+            Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], [
+                'tab_module' => $this->tab,
+                'module_name' => $this->name,
+                'configure' => $this->name,
+                'continue' => 1,
+                'type' => $new_link['type'],
+                'lang' => $lang,
+                'index' => $index,
+                'id' => (int) $id_obj,
+                'id_shop' => $this->context->shop->id,
+            ]));
         }
     }
 

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -295,9 +295,6 @@ class Gsitemap extends Module
                 ]);
 
                 return false;
-            } elseif ($index % 20 == 0 && $this->cron) {
-                header('Refresh: 5; url=http' . (Configuration::get('PS_SSL_ENABLED') ? 's' : '') . '://' . Tools::getShopDomain(false, true) . __PS_BASE_URI__ . 'modules/gsitemap/gsitemap-cron.php?continue=1&token=' . Tools::substr(Tools::hash('gsitemap/cron'), 0, 10) . '&type=' . $new_link['type'] . '&lang=' . $lang . '&index=' . $index . '&id=' . (int) $id_obj . '&id_shop=' . $this->context->shop->id);
-                exit();
             } else {
                 if ($this->cron) {
                     Tools::redirect($this->context->link->getBaseLink() . 'modules/gsitemap/gsitemap-cron.php?continue=1&token=' . Tools::substr(Tools::hash('gsitemap/cron'), 0, 10) . '&type=' . $new_link['type'] . '&lang=' . $lang . '&index=' . $index . '&id=' . (int) $id_obj . '&id_shop=' . $this->context->shop->id);

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -128,7 +128,9 @@
       <br><span style="font-style: italic;">{l s='-or-' d='Modules.Gsitemap.Admin'}</span><br><br>
       2. <strong>{l s='Automatically:' d='Modules.Gsitemap.Admin'}</strong> {l s='Ask your hosting provider to setup a "Cron job" to load the following URL at the time you would like:' d='Modules.Gsitemap.Admin'}
       <a href="{$gsitemap_cron|escape:'htmlall':'UTF-8'}" target="_blank">{$gsitemap_cron|escape:'htmlall':'UTF-8'}</a><br>
-      {l s='It will automatically generate your XML sitemaps.' d='Modules.Gsitemap.Admin'}
+      {l s='It will automatically generate your XML sitemaps.' d='Modules.Gsitemap.Admin'}<br>
+      {l s='If you are using a cron job in combination with a command-line tool, such as curl, and your shop is so large to require a large amount of XML sitemap files generated, you might need to modify the tools default redirect limit.'}<br>
+      {l s='For example: curl follows up to 50 redirects by default. To increase this number further, you will have to add the parameter "-L --max-redirs 99" to the curl command line in your cron job, which increases the redirect limit to 99 redirects.'}<br>
    </p>
    {/if}
    </p>

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -129,8 +129,8 @@
       2. <strong>{l s='Automatically:' d='Modules.Gsitemap.Admin'}</strong> {l s='Ask your hosting provider to setup a "Cron job" to load the following URL at the time you would like:' d='Modules.Gsitemap.Admin'}
       <a href="{$gsitemap_cron|escape:'htmlall':'UTF-8'}" target="_blank">{$gsitemap_cron|escape:'htmlall':'UTF-8'}</a><br>
       {l s='It will automatically generate your XML sitemaps.' d='Modules.Gsitemap.Admin'}<br>
-      {l s='If you are using a cron job in combination with a command-line tool, such as curl, and your shop is so large to require a large amount of XML sitemap files generated, you might need to modify the tools default redirect limit.'}<br>
-      {l s='For example: curl follows up to 50 redirects by default. To increase this number further, you will have to add the parameter "-L --max-redirs 99" to the curl command line in your cron job, which increases the redirect limit to 99 redirects.'}<br>
+      {l s='If you are using a cron job in combination with a command-line tool, such as curl, and your shop is so large to require a large amount of XML sitemap files generated, you might need to modify the tools default redirect limit.' d='Modules.Gsitemap.Admin'}<br>
+      {l s='For example: curl follows up to 50 redirects by default. To increase this number further, you will have to add the parameter "-L --max-redirs 99" to the curl command line in your cron job, which increases the redirect limit to 99 redirects.' d='Modules.Gsitemap.Admin'}<br>
    </p>
    {/if}
    </p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Full description below
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | To thoroughly test the sitemap generation process, it is necessary to have a sufficient number of products, images, and other pages or content. This will allow the generation of at least 20 sitemaps, which can then be used for testing purposes. The number of products required is not fixed and will depend on factors such as the number of images per product. For instance, for some shops it may be 5,000 products, for others 20,000 products. During the sitemap generation process, if a memory limit is exceeded (a specific check exists in gsitemap.php), the process may also move already to the next file with even less links processed. Currently, our shop has 200,000 products and 2.1 million images, resulting in the generation of 80 sitemap files. The size of these files varies between 2MB and 30MB. Prior to the patch, the generation process would always stop at the 20th file. However, after the patch, the sitemap generation process will continue until all available links are included in sitemap files, with the entire list of sitemap files being contained in the main `1_index_sitemap.xml` file. To run the test, execute the sitemap generation with the link for cron jobs given by the module on the CLI, as example: `/usr/bin/curl -L --max-redirs 99 "http://shop.com/modules/gsitemap/gsitemap-cron.php?token=1234..."` and check that sitemap generation adds files past `1_en_20_sitemap.xml`.

### Why this pull request?

When generating a sitemap using cron, a CLI tool like curl is typically employed to send an HTTP request to gsitemap-cron.php. For large sites with tens or hundreds of thousands of products, the module divides the sitemap files by size. However, the generation process halts after creating the 20th sitemap XML file, preventing the inclusion of all products in the sitemap. This pull request resolves this issue, enabling sitemap generation to proceed beyond the initial 20 files and ensuring that all products are added to the sitemap.

### What is the root of the issue?

The original code evaluates every 20 files generated and, rather than simply redirecting back to the module for the generation of the subsequent sitemap XML file, which would work, it sends an HTTP header "Refresh: 5" instead of an HTTP redirect.

This header lacks documentation (note that this refers to an HTTP header, not the meta refresh tag, which however is deprecated too)  and is absent from the HTTP standard. The Refresh HTTP header is a non-standard implementation from the Netscape era, which has only been maintained by browsers. Most, if not all, non-browser HTTP toolkits, such as curl, do not implement it. As a result, it is not guaranteed that using the Refresh HTTP header with tools other than browsers, which is almost always the case with cron jobs, will successfully complete the sitemap generation for very large shops. Rather the opposite, generation will stop with an unrecoverable error.

**Sources:**
https://github.com/curl/curl/issues/3657
https://daniel.haxx.se/blog/2019/03/12/looking-for-the-refresh-header/
https://github.com/request/request/issues/92
https://chromium-review.googlesource.com/c/chromium/src/+/1520146 (a possible intention to remove support even in chrome, because non-standard)

Moreover, there is no need or advantage to using this HTTP header for every 20th cron job redirect, as a simple redirect functions as intended, and the refresh – even if it were to work – serves no purpose.

### Changes introduced by the pull request

There are no deprecations or backward compatibility breaks, and no new or otherwise modified code that could potentially disrupt existing functionality. 

The only additional change involves simplifying the else statements and removing superfluous exit() statements for improved clarity and reduced complexity, as seen in this commit: https://github.com/dkarvounaris/gsitemap/commit/a504413e4f30c895997e17090245ae96292042c6?diff=split&w=1

Furthermore, I have updated the documentation to include information on the possible need of adjusting the number of redirects followed by the tool used in conjunction with cron jobs. This is particularly useful for very large shops which may require more redirects than the tool's default redirect limit. Something which can go otherwise unnoticed and may be difficult to debug. 