### PR TITLE
Do not include blocked pages

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -374,7 +374,6 @@ class Gsitemap extends Module
         $link = new Link();
         $metas = Db::getInstance()->ExecuteS('SELECT * FROM `' . _DB_PREFIX_ . 'meta` WHERE `configurable` > 0 AND `id_meta` >= ' . (int) $id_meta . ' AND page <> \'index\' ORDER BY `id_meta` ASC');
         foreach ($metas as $meta) {
-
             // Check if this meta is not in the list of blocked controllers in core robots.txt
             if (in_array($meta['page'], $this->disallow_controllers)) {
                 continue;

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -46,6 +46,16 @@ class Gsitemap extends Module
      */
     protected $type_array = [];
 
+    /**
+     * @var array
+     */
+    protected $disallow_controllers = [
+        'addresses', 'address', 'authentication', 'cart', 'discount', 'footer',
+        'get-file', 'header', 'history', 'identity', 'images.inc', 'init', 'my-account', 'order',
+        'order-slip', 'order-detail', 'order-follow', 'order-return', 'order-confirmation', 'pagination', 'password',
+        'pdf-invoice', 'pdf-order-return', 'pdf-order-slip', 'product-sort', 'registration', 'search', 'statistics', 'attachment', 'guest-tracking',
+    ];
+
     public function __construct()
     {
         $this->name = 'gsitemap';
@@ -207,9 +217,13 @@ class Gsitemap extends Module
         }
 
         /* Get Meta pages and remove index page it's managed elsewhere (@see $this->getHomeLink()) */
-        $store_metas = array_filter(Meta::getMetasByIdLang((int) $this->context->cookie->id_lang), function ($meta) {
-            return $meta['page'] != 'index';
-        });
+        /* We also remove all pages that are blocked in core robots.txt file */
+        $store_metas = array_filter(Meta::getMetasByIdLang(
+            (int) $this->context->cookie->id_lang),
+            function ($meta) {
+                return $meta['page'] != 'index' && !in_array($meta['page'], $this->disallow_controllers);
+            }
+        );
         $store_url = $this->context->link->getBaseLink();
         $this->context->smarty->assign([
             'gsitemap_form' => './index.php?tab=AdminModules&configure=gsitemap&token=' . Tools::getAdminTokenLite('AdminModules') . '&tab_module=' . $this->tab . '&module_name=gsitemap',
@@ -360,6 +374,12 @@ class Gsitemap extends Module
         $link = new Link();
         $metas = Db::getInstance()->ExecuteS('SELECT * FROM `' . _DB_PREFIX_ . 'meta` WHERE `configurable` > 0 AND `id_meta` >= ' . (int) $id_meta . ' AND page <> \'index\' ORDER BY `id_meta` ASC');
         foreach ($metas as $meta) {
+
+            // Check if this meta is not in the list of blocked controllers in core robots.txt
+            if (in_array($meta['page'], $this->disallow_controllers)) {
+                continue;
+            }
+
             $url = '';
             if (!in_array($meta['id_meta'], explode(',', Configuration::get('GSITEMAP_DISABLE_LINKS')))) {
                 $url = $link->getPageLink($meta['page'], null, $lang['id_lang']);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When generating robots.txt file, Prestashop marks some customer/internal pages as disallowed. [Check them out here.](https://github.com/PrestaShop/PrestaShop/blob/c54330d5a04972db3d86d3d88d8e2f359b0ac501/classes/Tools.php#L2570) This module allows them to be added to the XML sitemap, which results in errors in Search console, about these pages being in the sitemap, but not crawlable.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#18768
| How to test?  | See that the blocked pages no longer appear in module configuration and in the generated sitemap.