### PR TITLE
Hide stores from sitemap if none are configured

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -379,6 +379,11 @@ class Gsitemap extends Module
                 continue;
             }
 
+            // If no store is configured, we hide this page from sitemap
+            if ($meta['page'] == 'stores' && !$this->shouldIncludeStoresLink($lang['id_lang'])) {
+                continue;
+            }
+
             $url = '';
             if (!in_array($meta['id_meta'], explode(',', Configuration::get('GSITEMAP_DISABLE_LINKS')))) {
                 $url = $link->getPageLink($meta['page'], null, $lang['id_lang']);
@@ -395,6 +400,23 @@ class Gsitemap extends Module
         }
 
         return true;
+    }
+
+    /**
+     * Checks if at least 1 store is configured and if it makes sense to include this page in the XML.
+     *
+     * @param int $idLang
+     *
+     * @return bool
+     */
+    protected function shouldIncludeStoresLink($idLang)
+    {
+        // More performant way for 9.0 and newer
+        if (method_exists(Store::class, 'atLeastOneStoreExists')) {
+            return Store::atLeastOneStoreExists();
+        }
+
+        return !empty(Store::getStores($idLang));
     }
 
     /**

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -5,3 +5,4 @@ parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie\:\:\$id_lang.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie\:\:\$id_lang.#'
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -1,2 +1,6 @@
 includes:
     - %currentWorkingDirectory%/tests/phpstan/phpstan.neon
+
+parameters:
+  ignoreErrors:
+    - '~^Call to an undefined static method Store::atLeastOneStoreExists\(\)\.$~'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If no stores are configured, we hide stores page from XML sitemap. Two ways to get it, if a performant way is available, we do it. If not, just fetch the list.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#16133
| How to test?  | Delete all stores, regenerate XML sitemap and check that stores page is no longer included.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
