### PR TITLE
Remove function "GSITEMAP_CHECK_IMAGE_FILE" - too problematic

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>gsitemap</name>
     <displayName><![CDATA[Google sitemap]]></displayName>
-    <version><![CDATA[4.3.0]]></version>
+    <version><![CDATA[4.3.1]]></version>
     <description><![CDATA[Generate your Google sitemap file]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[seo]]></tab>

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -60,7 +60,7 @@ class Gsitemap extends Module
     {
         $this->name = 'gsitemap';
         $this->tab = 'checkout';
-        $this->version = '4.3.0';
+        $this->version = '4.3.1';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -108,7 +108,6 @@ class Gsitemap extends Module
             'GSITEMAP_PRIORITY_CATEGORY' => 0.8,
             'GSITEMAP_PRIORITY_CMS' => 0.7,
             'GSITEMAP_FREQUENCY' => 'weekly',
-            'GSITEMAP_CHECK_IMAGE_FILE' => false,
             'GSITEMAP_LAST_EXPORT' => false,
         ] as $key => $val) {
             if (!Configuration::updateValue($key, $val)) {
@@ -158,7 +157,6 @@ class Gsitemap extends Module
             'GSITEMAP_PRIORITY_CATEGORY' => '',
             'GSITEMAP_PRIORITY_CMS' => '',
             'GSITEMAP_FREQUENCY' => '',
-            'GSITEMAP_CHECK_IMAGE_FILE' => '',
             'GSITEMAP_LAST_EXPORT' => '',
         ] as $key => $val) {
             if (!Configuration::deleteByName($key)) {
@@ -197,7 +195,6 @@ class Gsitemap extends Module
         if (Tools::isSubmit('SubmitGsitemap')) {
             Configuration::updateValue('GSITEMAP_FREQUENCY', pSQL(Tools::getValue('gsitemap_frequency')));
             Configuration::updateValue('GSITEMAP_INDEX_CHECK', '');
-            Configuration::updateValue('GSITEMAP_CHECK_IMAGE_FILE', pSQL(Tools::getValue('gsitemap_check_image_file')));
             $meta = '';
             if (Tools::getValue('gsitemap_meta')) {
                 $meta .= implode(', ', Tools::getValue('gsitemap_meta'));
@@ -240,7 +237,6 @@ class Gsitemap extends Module
                 'memory_limit' => (int) ini_get('memory_limit'),
             ],
             'prestashop_ssl' => Configuration::get('PS_SSL_ENABLED'),
-            'gsitemap_check_image_file' => Configuration::get('GSITEMAP_CHECK_IMAGE_FILE'),
             'shop' => $this->context->shop,
         ]);
 
@@ -453,9 +449,7 @@ class Gsitemap extends Module
                         'http',
                         Context::getContext()->shop->domain . Context::getContext()->shop->physical_uri . Context::getContext()->shop->virtual_uri,
                     ], $image_link) : $image_link;
-                }
-                $file_headers = (Configuration::get('GSITEMAP_CHECK_IMAGE_FILE') && isset($image_link)) ? @get_headers($image_link) : true;
-                if (isset($image_link) && ((isset($file_headers[0]) && $file_headers[0] != 'HTTP/1.1 404 Not Found') || $file_headers === true)) {
+
                     $images_product[] = [
                         'title_img' => htmlspecialchars(strip_tags($product->name)),
                         'caption' => htmlspecialchars(strip_tags($product->meta_description)),
@@ -518,7 +512,7 @@ class Gsitemap extends Module
         foreach ($categories_id as $category_id) {
             $category = new Category((int) $category_id['id_category'], (int) $lang['id_lang']);
             $url = $link->getCategoryLink($category, urlencode($category->link_rewrite), (int) $lang['id_lang']);
-
+            $image_category = [];
             if ($category->id_image) {
                 $image_link = $this->context->link->getCatImageLink($category->link_rewrite, (int) $category->id_image, ImageType::getFormattedName('category'));
                 $image_link = (!in_array(rtrim(Context::getContext()->shop->virtual_uri, '/'), explode('/', $image_link))) ? str_replace([
@@ -528,10 +522,7 @@ class Gsitemap extends Module
                     'http',
                     Context::getContext()->shop->domain . Context::getContext()->shop->physical_uri . Context::getContext()->shop->virtual_uri,
                 ], $image_link) : $image_link;
-            }
-            $file_headers = (Configuration::get('GSITEMAP_CHECK_IMAGE_FILE') && isset($image_link)) ? @get_headers($image_link) : true;
-            $image_category = [];
-            if (isset($image_link) && ((isset($file_headers[0]) && $file_headers[0] != 'HTTP/1.1 404 Not Found') || $file_headers === true)) {
+
                 $image_category = [
                     'title_img' => htmlspecialchars(strip_tags($category->name)),
                     'caption' => Tools::substr(htmlspecialchars(strip_tags($category->description)), 0, 350),

--- a/upgrade/upgrade-4.3.1.php
+++ b/upgrade/upgrade-4.3.1.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_3_1($object)
+{
+    Configuration::deleteByName('GSITEMAP_CHECK_IMAGE_FILE');
+
+    return true;
+}

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -94,8 +94,6 @@
          <option{if $gsitemap_frequency == 'never'} selected="selected"{/if} value='never'>{l s='never' d='Modules.Gsitemap.Admin'}</option>
          </select></label>
       </div>
-      <label><input type="checkbox" name="gsitemap_check_image_file" value="1" {if $gsitemap_check_image_file}checked{/if}> {l s='Check this box if you wish to check the presence of the image files on the server' d='Modules.Gsitemap.Admin'}</label>
-      <br>
       <p>{l s='Indicate the pages that you do not want to include in your sitemap files:' d='Modules.Gsitemap.Admin'}</p>
       <button class="btn btn-secondary" type="button" id="check">{l s='Uncheck all' d='Modules.Gsitemap.Admin'}</button>
       <br>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Function GSITEMAP_CHECK_IMAGE_FILE in this module is crazy thing, and "every second" customer enable it without knowing impact, for example on performance (there is EVERY image "opened" via get_headers). If eshop have for example 100 000 images, every single images is analyzes, so, in most of cases error 500. But maybe worse is problem, they enable this, and in bigger eshops or slow webhosting it doesn't run to end, so sitemap is outdated years (I saw this about 5 times already). We should remove this. It's useless function.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #https://github.com/PrestaShop/PrestaShop/issues/34572 + #https://github.com/PrestaShop/PrestaShop/issues/32625 + #https://github.com/PrestaShop/PrestaShop/issues/18508
| How to test?  | Regenerate sitemap, check it went OK
