### PR TITLE
Re added manufacturers list

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>gsitemap</name>
     <displayName><![CDATA[Google sitemap]]></displayName>
-    <version><![CDATA[4.3.1]]></version>
+    <version><![CDATA[4.4.0]]></version>
     <description><![CDATA[Generate your Google sitemap file]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[seo]]></tab>

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -107,7 +107,7 @@ class Gsitemap extends Module
             'GSITEMAP_PRIORITY_HOME' => 1.0,
             'GSITEMAP_PRIORITY_PRODUCT' => 0.9,
             'GSITEMAP_PRIORITY_CATEGORY' => 0.8,
-			'GSITEMAP_PRIORITY_MANUFACTURER' => 0.7,
+            'GSITEMAP_PRIORITY_MANUFACTURER' => 0.7,
             'GSITEMAP_PRIORITY_CMS' => 0.7,
             'GSITEMAP_FREQUENCY' => 'weekly',
             'GSITEMAP_LAST_EXPORT' => false,
@@ -157,7 +157,7 @@ class Gsitemap extends Module
             'GSITEMAP_PRIORITY_HOME' => '',
             'GSITEMAP_PRIORITY_PRODUCT' => '',
             'GSITEMAP_PRIORITY_CATEGORY' => '',
-			'GSITEMAP_PRIORITY_MANUFACTURER' => '',
+            'GSITEMAP_PRIORITY_MANUFACTURER' => '',
             'GSITEMAP_PRIORITY_CMS' => '',
             'GSITEMAP_FREQUENCY' => '',
             'GSITEMAP_LAST_EXPORT' => '',
@@ -550,40 +550,40 @@ class Gsitemap extends Module
     }
 
     /**
-	 * return the link elements for the manufacturer object
-	 *
-	 * @param array  $link_sitemap    contain all the links for the Google Sitemap file to be generated
-	 * @param array  $lang            language of link to add
-	 * @param int    $index           index of the current Google Sitemap file
-	 * @param int    $i               count of elements added to sitemap main array
-	 * @param int    $id_manufacturer manufacturer object identifier
-	 *
-	 * @return bool
-	 */
-	protected function getManufacturerLink(&$link_sitemap, $lang, &$index, &$i, $id_manufacturer = 0)
-	{
-		$link = new Link();
-		if (method_exists('ShopUrl', 'resetMainDomainCache')) {
-			ShopUrl::resetMainDomainCache();
+     * return the link elements for the manufacturer object
+     *
+     * @param array  $link_sitemap    contain all the links for the Google Sitemap file to be generated
+     * @param array  $lang            language of link to add
+     * @param int    $index           index of the current Google Sitemap file
+     * @param int    $i               count of elements added to sitemap main array
+     * @param int    $id_manufacturer manufacturer object identifier
+     *
+     * @return bool
+     */
+    protected function getManufacturerLink(&$link_sitemap, $lang, &$index, &$i, $id_manufacturer = 0)
+    {
+        $link = new Link();
+        if (method_exists('ShopUrl', 'resetMainDomainCache')) {
+            ShopUrl::resetMainDomainCache();
         }
         
         // Get manufacturers IDs
-		$manufacturers_id = Db::getInstance()->ExecuteS('SELECT m.`id_manufacturer` FROM `' . _DB_PREFIX_ . 'manufacturer` m
-			INNER JOIN `' . _DB_PREFIX_ . 'manufacturer_lang` ml on m.`id_manufacturer` = ml.`id_manufacturer`' .
-			($this->tableColumnExists(_DB_PREFIX_ . 'manufacturer_shop') ? ' INNER JOIN `' . _DB_PREFIX_ . 'manufacturer_shop` ms ON m.`id_manufacturer` = ms.`id_manufacturer` ' : '').
-			' WHERE m.`active` = 1  AND m.`id_manufacturer` >= ' . (int)$id_manufacturer.
-			($this->tableColumnExists(_DB_PREFIX_ . 'manufacturer_shop') ? ' AND ms.`id_shop` = ' . (int)$this->context->shop->id : '').
-			' AND ml.`id_lang` = ' . (int)$lang['id_lang'].
-			' ORDER BY m.`id_manufacturer` ASC'
-		);
+        $manufacturers_id = Db::getInstance()->ExecuteS('SELECT m.`id_manufacturer` FROM `' . _DB_PREFIX_ . 'manufacturer` m
+            INNER JOIN `' . _DB_PREFIX_ . 'manufacturer_lang` ml on m.`id_manufacturer` = ml.`id_manufacturer`' .
+            ' INNER JOIN `' . _DB_PREFIX_ . 'manufacturer_shop` ms ON m.`id_manufacturer` = ms.`id_manufacturer`' .
+            ' WHERE m.`active` = 1  AND m.`id_manufacturer` >= ' . (int)$id_manufacturer .
+            ' AND ms.`id_shop` = ' . (int)$this->context->shop->id .
+            ' AND ml.`id_lang` = ' . (int)$lang['id_lang'] .
+            ' ORDER BY m.`id_manufacturer` ASC'
+        );
 
         // Process each manufacturer and add it to list of links that will be further "converted" to XML and added to the sitemap
-		foreach ($manufacturers_id as $manufacturer_id) {
-			$manufacturer = new Manufacturer((int) $manufacturer_id['id_manufacturer'], $lang['id_lang']);
-			$url = $link->getManufacturerLink($manufacturer, urlencode($manufacturer->link_rewrite), $lang['id_lang']);
+        foreach ($manufacturers_id as $manufacturer_id) {
+            $manufacturer = new Manufacturer((int) $manufacturer_id['id_manufacturer'], $lang['id_lang']);
+            $url = $link->getManufacturerLink($manufacturer, urlencode($manufacturer->link_rewrite), $lang['id_lang']);
 
-			$image_link = 'http'.(Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE') ? 's' : '').'://'.Tools::getMediaServer(_THEME_MANU_DIR_)._THEME_MANU_DIR_.((file_exists(_PS_MANU_IMG_DIR_.'/'.(int)$manufacturer->id.'-manu_default.jpg')) ? (int)$manufacturer->id.'-manu_default' : $lang['iso_code'].'-default-medium_default').'.jpg';
-			$image_link = (!in_array(rtrim(Context::getContext()->shop->virtual_uri, '/'), explode('/', $image_link))) ? str_replace([
+            $image_link = 'http'.(Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE') ? 's' : '').'://'.Tools::getMediaServer(_THEME_MANU_DIR_)._THEME_MANU_DIR_.((file_exists(_PS_MANU_IMG_DIR_.'/'.(int)$manufacturer->id.'-medium_default.jpg')) ? (int)$manufacturer->id.'-medium_default' : $lang['iso_code'].'-default-medium_default').'.jpg';
+            $image_link = (!in_array(rtrim(Context::getContext()->shop->virtual_uri, '/'), explode('/', $image_link))) ? str_replace([
                 'https',
                 Context::getContext()->shop->domain . Context::getContext()->shop->physical_uri,
             ], [
@@ -591,30 +591,30 @@ class Gsitemap extends Module
                 Context::getContext()->shop->domain . Context::getContext()->shop->physical_uri . Context::getContext()->shop->virtual_uri,
             ], $image_link) : $image_link;
 
-			$manifacturer_image = [];
-			if (isset($image_link)) {
-				$manifacturer_image = [
-					'title_img' => htmlspecialchars(strip_tags($manufacturer->name)),
-					'caption' => htmlspecialchars(strip_tags($manufacturer->short_description)),
-					'link' => $image_link,
-				];
+            $manifacturer_image = [];
+            if (isset($image_link)) {
+                $manifacturer_image = [
+                    'title_img' => htmlspecialchars(strip_tags($manufacturer->name)),
+                    'caption' => htmlspecialchars(strip_tags($manufacturer->short_description)),
+                    'link' => $image_link,
+                ];
             }
 
-			if (!$this->addLinkToSitemap($link_sitemap, [
+            if (!$this->addLinkToSitemap($link_sitemap, [
                 'type' => 'manufacturer',
                 'page' => 'manufacturer',
                 'lastmod' => $manufacturer->date_upd,
                 'link' => $url,
                 'image' => $manifacturer_image
             ], $lang['iso_code'], $index, $i, $manufacturer_id['id_manufacturer'])) {
-			    return false;
+                return false;
             }
 
             unset($image_link);
-		}
+        }
 
-		return true;
-	}
+        return true;
+    }
 
     /**
      * return the link elements for the CMS object
@@ -633,8 +633,8 @@ class Gsitemap extends Module
         if (method_exists('ShopUrl', 'resetMainDomainCache')) {
             ShopUrl::resetMainDomainCache();
         }
-        $cmss_id = Db::getInstance()->ExecuteS('SELECT c.`id_cms` FROM `' . _DB_PREFIX_ . 'cms` c INNER JOIN `' . _DB_PREFIX_ . 'cms_lang` cl ON c.`id_cms` = cl.`id_cms` ' . ($this->tableColumnExists(_DB_PREFIX_ . 'supplier_shop') ? 'INNER JOIN `' . _DB_PREFIX_ . 'cms_shop` cs ON c.`id_cms` = cs.`id_cms` ' : '') . 'INNER JOIN `' . _DB_PREFIX_ . 'cms_category` cc ON c.id_cms_category = cc.id_cms_category AND cc.active = 1
-            WHERE c.`active` =1 AND c.`indexation` =1 AND c.`id_cms` >= ' . (int) $id_cms . ($this->tableColumnExists(_DB_PREFIX_ . 'supplier_shop') ? ' AND cs.id_shop = ' . (int) $this->context->shop->id : '') . ' AND cl.`id_lang` = ' . (int) $lang['id_lang'] . ' GROUP BY  c.`id_cms` ORDER BY c.`id_cms` ASC');
+        $cmss_id = Db::getInstance()->ExecuteS('SELECT c.`id_cms` FROM `' . _DB_PREFIX_ . 'cms` c INNER JOIN `' . _DB_PREFIX_ . 'cms_lang` cl ON c.`id_cms` = cl.`id_cms` ' . 'INNER JOIN `' . _DB_PREFIX_ . 'cms_shop` cs ON c.`id_cms` = cs.`id_cms` ' . 'INNER JOIN `' . _DB_PREFIX_ . 'cms_category` cc ON c.id_cms_category = cc.id_cms_category AND cc.active = 1
+            WHERE c.`active` =1 AND c.`indexation` =1 AND c.`id_cms` >= ' . (int) $id_cms . ' AND cs.id_shop = ' . (int) $this->context->shop->id . ' AND cl.`id_lang` = ' . (int) $lang['id_lang'] . ' GROUP BY  c.`id_cms` ORDER BY c.`id_cms` ASC');
 
         if (is_array($cmss_id)) {
             foreach ($cmss_id as $cms_id) {

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -591,21 +591,18 @@ class Gsitemap extends Module
                 Context::getContext()->shop->domain . Context::getContext()->shop->physical_uri . Context::getContext()->shop->virtual_uri,
             ], $image_link) : $image_link;
 
-            $manifacturer_image = [];
-            if (isset($image_link)) {
-                $manifacturer_image = [
-                    'title_img' => htmlspecialchars(strip_tags($manufacturer->name)),
-                    'caption' => htmlspecialchars(strip_tags($manufacturer->short_description)),
-                    'link' => $image_link,
-                ];
-            }
+            $manufacturer_image = [
+                'title_img' => htmlspecialchars(strip_tags($manufacturer->name)),
+                'caption' => htmlspecialchars(strip_tags($manufacturer->short_description)),
+                'link' => $image_link,
+            ];
 
             if (!$this->addLinkToSitemap($link_sitemap, [
                 'type' => 'manufacturer',
                 'page' => 'manufacturer',
                 'lastmod' => $manufacturer->date_upd,
                 'link' => $url,
-                'image' => $manifacturer_image
+                'image' => $manufacturer_image
             ], $lang['iso_code'], $index, $i, $manufacturer_id['id_manufacturer'])) {
                 return false;
             }

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -60,7 +60,7 @@ class Gsitemap extends Module
     {
         $this->name = 'gsitemap';
         $this->tab = 'checkout';
-        $this->version = '4.3.1';
+        $this->version = '4.4.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -552,11 +552,11 @@ class Gsitemap extends Module
     /**
      * return the link elements for the manufacturer object
      *
-     * @param array  $link_sitemap    contain all the links for the Google Sitemap file to be generated
-     * @param array  $lang            language of link to add
-     * @param int    $index           index of the current Google Sitemap file
-     * @param int    $i               count of elements added to sitemap main array
-     * @param int    $id_manufacturer manufacturer object identifier
+     * @param array $link_sitemap contain all the links for the Google Sitemap file to be generated
+     * @param array $lang language of link to add
+     * @param int $index index of the current Google Sitemap file
+     * @param int $i count of elements added to sitemap main array
+     * @param int $id_manufacturer manufacturer object identifier
      *
      * @return bool
      */
@@ -566,14 +566,14 @@ class Gsitemap extends Module
         if (method_exists('ShopUrl', 'resetMainDomainCache')) {
             ShopUrl::resetMainDomainCache();
         }
-        
+
         // Get manufacturers IDs
         $manufacturers_id = Db::getInstance()->ExecuteS('SELECT m.`id_manufacturer` FROM `' . _DB_PREFIX_ . 'manufacturer` m
             INNER JOIN `' . _DB_PREFIX_ . 'manufacturer_lang` ml on m.`id_manufacturer` = ml.`id_manufacturer`' .
             ' INNER JOIN `' . _DB_PREFIX_ . 'manufacturer_shop` ms ON m.`id_manufacturer` = ms.`id_manufacturer`' .
-            ' WHERE m.`active` = 1  AND m.`id_manufacturer` >= ' . (int)$id_manufacturer .
-            ' AND ms.`id_shop` = ' . (int)$this->context->shop->id .
-            ' AND ml.`id_lang` = ' . (int)$lang['id_lang'] .
+            ' WHERE m.`active` = 1  AND m.`id_manufacturer` >= ' . (int) $id_manufacturer .
+            ' AND ms.`id_shop` = ' . (int) $this->context->shop->id .
+            ' AND ml.`id_lang` = ' . (int) $lang['id_lang'] .
             ' ORDER BY m.`id_manufacturer` ASC'
         );
 
@@ -582,7 +582,7 @@ class Gsitemap extends Module
             $manufacturer = new Manufacturer((int) $manufacturer_id['id_manufacturer'], $lang['id_lang']);
             $url = $link->getManufacturerLink($manufacturer, urlencode($manufacturer->link_rewrite), $lang['id_lang']);
 
-            $image_link = 'http'.(Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE') ? 's' : '').'://'.Tools::getMediaServer(_THEME_MANU_DIR_)._THEME_MANU_DIR_.((file_exists(_PS_MANU_IMG_DIR_.'/'.(int)$manufacturer->id.'-medium_default.jpg')) ? (int)$manufacturer->id.'-medium_default' : $lang['iso_code'].'-default-medium_default').'.jpg';
+            $image_link = $this->context->link->getManufacturerImageLink((int) $manufacturer->id, ImageType::getFormattedName('medium'));
             $image_link = (!in_array(rtrim(Context::getContext()->shop->virtual_uri, '/'), explode('/', $image_link))) ? str_replace([
                 'https',
                 Context::getContext()->shop->domain . Context::getContext()->shop->physical_uri,
@@ -602,7 +602,7 @@ class Gsitemap extends Module
                 'page' => 'manufacturer',
                 'lastmod' => $manufacturer->date_upd,
                 'link' => $url,
-                'image' => $manufacturer_image
+                'image' => $manufacturer_image,
             ], $lang['iso_code'], $index, $i, $manufacturer_id['id_manufacturer'])) {
                 return false;
             }

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '#Parameter \#2 \$type of method LinkCore\:\:getManufacturerImageLink\(\) expects null, string given.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '#Parameter \#2 \$type of method LinkCore\:\:getManufacturerImageLink\(\) expects null, string given.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '#Parameter \#2 \$type of method LinkCore\:\:getManufacturerImageLink\(\) expects null, string given.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '#Parameter \#2 \$type of method LinkCore\:\:getManufacturerImageLink\(\) expects null, string given.#'

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '#Parameter \#2 \$type of method LinkCore\:\:getManufacturerImageLink\(\) expects null, string given.#'

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'
     - '#Parameter \#2 \$idLang of class Category constructor expects null, int given.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '#Parameter \#2 \$type of method LinkCore\:\:getManufacturerImageLink\(\) expects null, string given.#'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -5,3 +5,4 @@ parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie\:\:\$id_lang.#'
     - '#Parameter \#3 \$type of method LinkCore\:\:getCatImageLink\(\) expects null, string given.#'
+    - '#Parameter \#2 \$type of method LinkCore\:\:getManufacturerImageLink\(\) expects null, string given.#'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie\:\:\$id_lang.#'
+    - '#Parameter \#1 \$str of function strip_tags expects string, array<string> given.#'

--- a/upgrade/upgrade-4.4.0.php
+++ b/upgrade/upgrade-4.4.0.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_4_0($object)
+{
+    Configuration::updateValue('GSITEMAP_PRIORITY_MANUFACTURER', 0.7);
+
+    return true;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Re add Manufacturer (list) to Sitemap XML. Was in the version 3.2.2 but disappeared. I personally need it and I found others that need it too (like in this [issue#17771](https://github.com/PrestaShop/PrestaShop/issues/17771)). Someone tried to get it back, but the PR was closed #126.  We also remove the calls to tableColumnExists (**) Keep the method in case is need in the future.
| Type?         | "new feature" (was removed with no reason as far as I know)
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#17771.
| How to test?  | Create a Manufacturer (Try adding one with image another without to check the image link) and regenerate Sitemap. You will see the URL of that manufacturer and some extra info. 

(**) by [Hlavtox](https://github.com/Hlavtox)  
> We can remove all calls to tableColumnExists along with that method. The Db structure is the same since 1.7.1.0)

Improvements for future versions:
It will be great to have a "checkbox" to let the user easily check if wants it or not in the Sitemap.
Also, have the option to choose which one you want in your sitemap (because maybe you just want the 3 best.

A screenshot of the test I made:

![Sitemap_result](https://github.com/PrestaShop/gsitemap/assets/6587126/b97c0957-6815-4425-8e2b-0ec22863e934)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
