### PR TITLE
Add controller for CRON tasks and minor fixes

### DIFF
--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+class GsitemapCronModuleFrontController extends ModuleFrontController
+{
+    public function postProcess()
+    {
+        // Check correct token when not in CLI context
+        if (!Tools::isPHPCLI() && Tools::substr(Tools::hash('gsitemap/cron'), 0, 10) != Tools::getValue('token')) {
+            exit('Bad token');
+        }
+
+        // Check if the requested shop exists
+        $shops = Db::getInstance()->ExecuteS('SELECT id_shop FROM `' . _DB_PREFIX_ . 'shop`');
+        $list_id_shop = [];
+        foreach ($shops as $shop) {
+            $list_id_shop[] = (int) $shop['id_shop'];
+        }
+
+        $id_shop = (Tools::getIsset('id_shop') && in_array(Tools::getValue('id_shop'), $list_id_shop)) ? (int) Tools::getValue('id_shop') : (int) Configuration::get('PS_SHOP_DEFAULT');
+
+        // Mark a flag that we are in cron context
+        $this->module->cron = true;
+
+        // If this is the first request to generate, we delete all previous sitemaps
+        if (!Tools::getIsset('continue')) {
+            $this->module->emptySitemap((int) $id_shop);
+        }
+
+        // Run generation
+        $this->module->createSitemap((int) $id_shop);
+    }
+}

--- a/controllers/front/index.php
+++ b/controllers/front/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/controllers/index.php
+++ b/controllers/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/gsitemap-cron.php
+++ b/gsitemap-cron.php
@@ -25,8 +25,11 @@
  */
 
 /*
- * This file can be called using a cron to generate Google sitemap files automatically
+ * This file can be called using a cron to generate Google sitemap files automatically.
+ * This file should no longer be used and will be removed in 5.0.0 version of this module.
+ * Please update your cron tasks to use the new URL available in module settings.
  */
+trigger_error('This file should no longer be used and will be removed in 5.0.0 version of this module. Please update your cron tasks to use the new URL available in module settings.', E_USER_NOTICE);
 
 include dirname(__FILE__) . '/../../config/config.inc.php';
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Added new controller to make module compatible with Prestashop 9. Removes some unused code, adds some missing configuration values. Adds a deprecation notice to current cron task.
| Type?         | refacto
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? | 
| How to test?  | Test that sitemap generates normally. Test that if you call the old URL, you get a notice. `http://localhost/dev/modules/gsitemap/gsitemap-cron.php?token=YOURTOKEN&id_shop=1`
