### PR TITLE
remove caption and title tags of the images

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -474,8 +474,6 @@ class Gsitemap extends Module
                     ], $image_link) : $image_link;
 
                     $images_product[] = [
-                        'title_img' => htmlspecialchars(strip_tags($product->name)),
-                        'caption' => htmlspecialchars(strip_tags($product->meta_description)),
                         'link' => $image_link,
                     ];
                 }
@@ -547,8 +545,6 @@ class Gsitemap extends Module
                 ], $image_link) : $image_link;
 
                 $image_category = [
-                    'title_img' => htmlspecialchars(strip_tags($category->name)),
-                    'caption' => Tools::substr(htmlspecialchars(strip_tags($category->description)), 0, 350),
                     'link' => $image_link,
                 ];
             }
@@ -612,8 +608,6 @@ class Gsitemap extends Module
             ], $image_link) : $image_link;
 
             $manufacturer_image = [
-                'title_img' => htmlspecialchars(strip_tags($manufacturer->name)),
-                'caption' => htmlspecialchars(strip_tags($manufacturer->short_description)),
                 'link' => $image_link,
             ];
 
@@ -820,15 +814,7 @@ class Gsitemap extends Module
                 $images = array_merge($images, $file['images']);
             }
             foreach ($images as $image) {
-                $this->addSitemapNodeImage($write_fd, htmlspecialchars(strip_tags($image['link'])), isset($image['title_img']) ? htmlspecialchars(str_replace([
-                    "\r\n",
-                    "\r",
-                    "\n",
-                ], '', $this->removeControlCharacters(strip_tags($image['title_img'])))) : '', isset($image['caption']) ? htmlspecialchars(str_replace([
-                    "\r\n",
-                    "\r",
-                    "\n",
-                ], '', strip_tags($image['caption']))) : '');
+                $this->addSitemapNodeImage($write_fd, htmlspecialchars(strip_tags($image['link'])));
             }
             fwrite($write_fd, '</url>' . PHP_EOL);
         }
@@ -870,9 +856,9 @@ class Gsitemap extends Module
         );
     }
 
-    protected function addSitemapNodeImage($fd, $link, $title, $caption)
+    protected function addSitemapNodeImage($fd, $link)
     {
-        fwrite($fd, '<image:image>' . PHP_EOL . '<image:loc>' . (Configuration::get('PS_REWRITING_SETTINGS') ? '<![CDATA[' . $link . ']]>' : $link) . '</image:loc>' . PHP_EOL . '<image:caption><![CDATA[' . $caption . ']]></image:caption>' . PHP_EOL . '<image:title><![CDATA[' . $title . ']]></image:title>' . PHP_EOL . '</image:image>' . PHP_EOL);
+        fwrite($fd, '<image:image>' . PHP_EOL . '<image:loc>' . (Configuration::get('PS_REWRITING_SETTINGS') ? '<![CDATA[' . $link . ']]>' : $link) . '</image:loc>' . PHP_EOL . '</image:image>' . PHP_EOL);
     }
 
     /**

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -4,4 +4,3 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie\:\:\$id_lang.#'
-    - '#Parameter \#1 \$str of function strip_tags expects string, array<string> given.#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Google has stopped using the tags `<image:caption>, <image:geo_location>, <image:title>, <image:license>`, so we can delete that part from the code, making sitemap file lighter (good for big stores).
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | -
| How to test?  | Just generate a new sitemap

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Links: 
- [https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps#deprecated](url)
- [https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions](url)
