### PR TITLE
Fix link for generate site map

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -226,8 +226,12 @@ class Gsitemap extends Module
             }
         );
         $store_url = $this->context->link->getBaseLink();
+        $gsitemap_form = '';
+        if (version_compare(_PS_VERSION_, '9.0.0', '<')) {
+            $gsitemap_form = './index.php?controller=AdminModules&configure=gsitemap&token=' . Tools::getAdminTokenLite('AdminModules') . '&tab_module=' . $this->tab . '&module_name=gsitemap';
+        }
         $this->context->smarty->assign([
-            'gsitemap_form' => './index.php?controller=AdminModules&configure=gsitemap&token=' . Tools::getAdminTokenLite('AdminModules') . '&tab_module=' . $this->tab . '&module_name=gsitemap',
+            'gsitemap_form' => $gsitemap_form,
             'gsitemap_cron' => $this->context->link->getModuleLink(
                 'gsitemap',
                 'cron',

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -227,6 +227,7 @@ class Gsitemap extends Module
         );
         $store_url = $this->context->link->getBaseLink();
         $this->context->smarty->assign([
+            'gsitemap_form' => $this->context->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name,
             'gsitemap_cron' => $this->context->link->getModuleLink(
                 'gsitemap',
                 'cron',
@@ -762,7 +763,7 @@ class Gsitemap extends Module
         if ($this->cron) {
             exit();
         }
-        Tools::redirectAdmin('index.php?controller=AdminModules&configure=gsitemap&token=' . Tools::getAdminTokenLite('AdminModules') . '&tab_module=' . $this->tab . '&module_name=gsitemap&validation');
+        Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name . '&validation');
         exit();
     }
 

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -227,7 +227,11 @@ class Gsitemap extends Module
         );
         $store_url = $this->context->link->getBaseLink();
         $this->context->smarty->assign([
-            'gsitemap_form' => $this->context->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name,
+            'gsitemap_form' => $this->context->link->getAdminLink('AdminModules', true, [], [
+                'configure' => $this->name,
+                'tab_module' => $this->tab,
+                'module_name' => $this->name,
+            ]),
             'gsitemap_cron' => $this->context->link->getModuleLink(
                 'gsitemap',
                 'cron',
@@ -763,7 +767,12 @@ class Gsitemap extends Module
         if ($this->cron) {
             exit();
         }
-        Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name . '&validation');
+        Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], [
+            'configure' => $this->name,
+            'tab_module' => $this->tab,
+            'module_name' => $this->name,
+            'validation' => 1,
+        ]));
         exit();
     }
 

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -226,12 +226,7 @@ class Gsitemap extends Module
             }
         );
         $store_url = $this->context->link->getBaseLink();
-        $gsitemap_form = '';
-        if (version_compare(_PS_VERSION_, '9.0.0', '<')) {
-            $gsitemap_form = './index.php?controller=AdminModules&configure=gsitemap&token=' . Tools::getAdminTokenLite('AdminModules') . '&tab_module=' . $this->tab . '&module_name=gsitemap';
-        }
         $this->context->smarty->assign([
-            'gsitemap_form' => $gsitemap_form,
             'gsitemap_cron' => $this->context->link->getModuleLink(
                 'gsitemap',
                 'cron',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix link for generate site map since 9.0.0
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/39152
| How to test?  | **Use Ngnix** Active multishop and choose a Shop, go to site map and Try to generate site map in 8.x and 9.x and 1.7.1 +
| Sponsor company   | @Touxten 

This PR need https://github.com/PrestaShop/gsitemap/pull/185 for TESTS

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
