### PR TITLE
Skip meta pages whose route requires mandatory parameters in sitemap

### DIFF
--- a/gsitemap.php
+++ b/gsitemap.php
@@ -481,7 +481,15 @@ class Gsitemap extends Module
 
             $url = '';
             if (!in_array($meta['id_meta'], explode(',', Configuration::get('GSITEMAP_DISABLE_LINKS')))) {
-                $url = $link->getPageLink($meta['page'], null, $lang['id_lang']);
+                try {
+                    $url = $link->getPageLink($meta['page'], null, $lang['id_lang']);
+                } catch (PrestaShopException $e) {
+                    // Some meta pages map to routes that require mandatory parameters
+                    // (e.g. a module search route needing an id). Such routes cannot be
+                    // represented in a sitemap without a specific value, so we skip them
+                    // instead of aborting the whole sitemap generation.
+                    continue;
+                }
 
                 if (!$this->addLinkToSitemap($link_sitemap, [
                     'type' => 'meta',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `getMetaLink()` builds a sitemap entry for every configurable meta page via `Link::getPageLink($meta['page'], ...)`. When a meta page maps to a route that requires a mandatory parameter (e.g. a module search route needing an id), `Dispatcher::createUrl()` throws a `PrestaShopException`, which aborted the **entire** sitemap generation. This PR catches that exception and skips the offending page so generation continues. Such routes cannot be represented in a sitemap without a specific parameter value, so skipping them is the expected behaviour.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/gsitemap#193.
| How to test?      | Install a module that registers a meta page mapping to a route with a required parameter (issue example: `module-pm_advancedsearch-searchresults` requiring `id_search`), then generate the sitemap from the gsitemap configuration page. Before this PR generation fails with `Dispatcher::createUrl() miss required parameter ...`; after it the sitemap is generated and the route is silently skipped. This is reproducible with a core route too: `Link::getPageLink('upload', null, $idLang)` throws (the `upload` route requires `file`) — with the fix, `getMetaLink()` skips it and returns normally instead of aborting.
| Sponsor company   |
